### PR TITLE
send invitation at vote creation

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+SITE_URL=http://localhost:8000
+DEFAULT_FROM_EMAIL=dont-answer@mieuxvoter.fr
+EMAIL_HOST=mail
+EMAIL_PORT=25

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       - "8012:8000"
     depends_on:
       - db
-
+    env_file:
+      - .env
+  mail:
+    image: bytemark/smtp
+    restart: always
 
 

--- a/election/tests.py
+++ b/election/tests.py
@@ -1,4 +1,5 @@
 import logging
+from django.core import mail
 from django.db import IntegrityError
 from django.test import TestCase
 from rest_framework.test import APITestCase
@@ -126,6 +127,27 @@ class VoteOnInvitationViewTestCase(APITestCase):
 
 
         self.assertEqual(400, response.status_code)
+
+
+class MailForCreationTestCase(TestCase):
+
+    def test_send_mail(self):
+        
+        response_post = self.client.post(
+            urls.new_election(),
+            {
+                "title": "Test",
+                "candidates": ["A", "B"],
+                "on_invitation_only": False,
+                "num_grades": 5,
+                "elector_emails": ["name@example.com"],
+            },
+        )
+
+        election_pk = response_post.data["id"]
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("/vote/" + election_pk, mail.outbox[0].body)
 
 
 class ResutsTestCase(TestCase):

--- a/election/views.py
+++ b/election/views.py
@@ -1,4 +1,9 @@
 from django.db import IntegrityError
+from django.conf import settings
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+
+
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.generics import CreateAPIView, RetrieveAPIView
@@ -15,7 +20,21 @@ UNKNOWN_ELECTION_ERROR = "E1: Unknown election"
 ONGOING_ELECTION_ERROR = "E2: Ongoing election"
 NO_VOTE_ERROR = "E3: No recorded vote"
 
-
+def send_mail_invitation(email, election):   
+    send_mail(
+        election.title,
+        render_to_string(
+            "election/mail_invitation.txt",
+            {
+                "invitation_url":
+                    settings.SITE_URL + "/vote/" + election.id,
+                "title": election.title,
+            }
+        ),
+        settings.DEFAULT_FROM_EMAIL,
+        [ email ]
+    )
+    
 
 class ElectionCreateAPIView(CreateAPIView):
     serializer_class = serializers.ElectionCreateSerializer
@@ -25,20 +44,19 @@ class ElectionCreateAPIView(CreateAPIView):
         serializer.is_valid(raise_exception=True)
 
         election = serializer.save()
-        for email in serializer.validated_data.get("elector_emails", []):
+        electors_emails = serializer.validated_data.get("elector_emails", [])
+        for email in electors_emails:
             if election.on_invitation_only:
                 token = Token.objects.create(
                     election=election,
                     email=email,
                 )
-                print(
+                print(# TODO!
                     "Send mail : id election: %s, token: %s, email: %s"
                     %(election.id, token.id, email)
                 )
             else:
-                print("Send mail: id election: %s, email: %s"
-                    %(election.id, email)
-                )
+                send_mail_invitation(email, election)
 
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)

--- a/mvapi/settings.py
+++ b/mvapi/settings.py
@@ -15,6 +15,7 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+SITE_URL = os.environ['SITE_URL']
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
@@ -58,7 +59,7 @@ ROOT_URLCONF = 'mvapi.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -124,3 +125,16 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+################################################################################
+#                                                                              #
+#                       MAIL SETTINGS                                          #
+#                                                                              #
+################################################################################
+DEFAULT_FROM_EMAIL = os.environ['DEFAULT_FROM_EMAIL']
+EMAIL_HOST = os.environ['EMAIL_HOST']
+EMAIL_PORT = int(os.environ['EMAIL_PORT'])
+if os.environ.get('EMAIL_USE_TLS') in ("True", "true", "on", "1"):
+    EMAIL_USE_TLS = True
+else:
+    EMAIL_USE_TLS = False

--- a/templates/election/mail_invitation.txt
+++ b/templates/election/mail_invitation.txt
@@ -1,0 +1,2 @@
+Please answer the question {{ title }} by clicking this link:
+{{ invitation_url | safe }}


### PR DESCRIPTION
Problem: no messages was actually sent to electors when a list of elector emails was provided

Solution (partial): send an email to all the electors when an election without "private token" is created. Currently, only the link to the vote is sent (it would be great to also have the link to the results).

